### PR TITLE
Only change EditText's text is the value is different

### DIFF
--- a/library/src/main/java/com/github/mproberts/rxdatabinding/bindings/EditTextViewDataBindings.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/bindings/EditTextViewDataBindings.java
@@ -33,7 +33,9 @@ public class EditTextViewDataBindings {
         DataBindingTools.bindViewProperty(android.R.attr.text, new Consumer<String>() {
             @Override
             public void accept(String s) throws Exception {
-                view.setText(s);
+                if (view.getText() == null || !view.getText().toString().equals(s)) {
+                    view.setText(s);
+                }
             }
         }, view, newValue);
     }


### PR DESCRIPTION
This allows us to avoid weird caret behavior when setting the value to itself.