### PR TITLE
Fix notifications intents not being properly received

### DIFF
--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -244,7 +244,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
 
-        return PendingIntent.getBroadcast(getContext(), 0, intent, 0);
+        return PendingIntent.getBroadcast(getContext(), notificationId, intent, 0);
     }
 
     private PendingIntent createBoundActionIntent(int notificationId, Class<? extends Activity> activity, String actionName) {
@@ -256,7 +256,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
         intent.putExtra(KEY_MAPPED_ACTION, actionName);
 
-        return PendingIntent.getActivity(getContext(), 0, intent, 0);
+        return PendingIntent.getActivity(getContext(), notificationId, intent, 0);
     }
 
     public interface NotificationCreator<T> {

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -447,7 +447,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
 
         String action = intent.getAction();
 
-        if (action != null && action.startsWith(getActionDismissId())) {
+        if (getActionDismissId().equals(action)) {
             int notificationId = intent.getIntExtra(KEY_NOTIFICATION_ID, INVALID_NOTIFICATION_ID);
 
             if (notificationId == INVALID_NOTIFICATION_ID) {
@@ -460,7 +460,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
                     break;
                 }
             }
-        } else if (action != null && action.startsWith(getActionModelEventId())) {
+        } else if (getActionModelEventId().equals(action)) {
             int notificationId = intent.getIntExtra(KEY_NOTIFICATION_ID, INVALID_NOTIFICATION_ID);
             String actionName = intent.getStringExtra(KEY_MAPPED_ACTION);
 

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -244,7 +244,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
 
-        return PendingIntent.getBroadcast(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(getContext(), 0, intent, 0);
     }
 
     private PendingIntent createBoundActionIntent(int notificationId, Class<? extends Activity> activity, String actionName) {

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -240,23 +240,23 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         Intent intent = new Intent()
                 .addFlags(Intent.FLAG_FROM_BACKGROUND)
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                .setAction(getActionDismissId() + notificationId);
+                .setAction(getActionDismissId());
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
 
-        return PendingIntent.getBroadcast(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(getContext(), notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private PendingIntent createBoundActionIntent(int notificationId, Class<? extends Activity> activity, String actionName) {
         Intent intent = new Intent(getContext(), activity)
                 .addFlags(Intent.FLAG_FROM_BACKGROUND)
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                .setAction(getActionModelEventId() + notificationId);
+                .setAction(getActionModelEventId());
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
         intent.putExtra(KEY_MAPPED_ACTION, actionName);
 
-        return PendingIntent.getActivity(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getActivity(getContext(), notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     public interface NotificationCreator<T> {

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -256,7 +256,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
         intent.putExtra(KEY_MAPPED_ACTION, actionName);
 
-        return PendingIntent.getActivity(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getActivity(getContext(), 0, intent, 0);
     }
 
     public interface NotificationCreator<T> {

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -244,7 +244,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
 
-        return PendingIntent.getBroadcast(getContext(), notificationId, intent, 0);
+        return PendingIntent.getBroadcast(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private PendingIntent createBoundActionIntent(int notificationId, Class<? extends Activity> activity, String actionName) {
@@ -256,7 +256,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
         intent.putExtra(KEY_MAPPED_ACTION, actionName);
 
-        return PendingIntent.getActivity(getContext(), notificationId, intent, 0);
+        return PendingIntent.getActivity(getContext(), 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     public interface NotificationCreator<T> {

--- a/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
+++ b/library/src/main/java/com/github/mproberts/rxdatabinding/notifications/NotificationBindingHandler.java
@@ -240,7 +240,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         Intent intent = new Intent()
                 .addFlags(Intent.FLAG_FROM_BACKGROUND)
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                .setAction(getActionDismissId());
+                .setAction(getActionDismissId() + notificationId);
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
 
@@ -251,7 +251,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
         Intent intent = new Intent(getContext(), activity)
                 .addFlags(Intent.FLAG_FROM_BACKGROUND)
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                .setAction(getActionModelEventId());
+                .setAction(getActionModelEventId() + notificationId);
 
         intent.putExtra(KEY_NOTIFICATION_ID, notificationId);
         intent.putExtra(KEY_MAPPED_ACTION, actionName);
@@ -447,7 +447,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
 
         String action = intent.getAction();
 
-        if (getActionDismissId().equals(action)) {
+        if (action != null && action.startsWith(getActionDismissId())) {
             int notificationId = intent.getIntExtra(KEY_NOTIFICATION_ID, INVALID_NOTIFICATION_ID);
 
             if (notificationId == INVALID_NOTIFICATION_ID) {
@@ -460,7 +460,7 @@ public class NotificationBindingHandler<T> extends BroadcastReceiver {
                     break;
                 }
             }
-        } else if (getActionModelEventId().equals(action)) {
+        } else if (action != null && action.startsWith(getActionModelEventId())) {
             int notificationId = intent.getIntExtra(KEY_NOTIFICATION_ID, INVALID_NOTIFICATION_ID);
             String actionName = intent.getStringExtra(KEY_MAPPED_ACTION);
 


### PR DESCRIPTION
Turns out if you use the same request code and action, you'll only receive the intent for the last notification (since all intents are going to the same activity).

Food for thought:
https://stackoverflow.com/questions/9048992/wrong-intent-receveid-in-activity-from-notification-in-service
https://medium.com/@krossovochkin/android-notifications-overview-and-pitfalls-517d1118ec83