### PR TITLE
Update rxtools

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api "io.reactivex.rxjava2:rxjava:2.1.14"
     testImplementation 'junit:junit:4.12'
 //    api 'androidx.annotation:annotation:1.0.0-beta01'
-    api 'com.github.mproberts:rxtools:0.5.2'
+    api 'com.github.mproberts:rxtools:a47236f6ee'
 }


### PR DESCRIPTION
@mproberts I think it's causing issues elsewhere since we're referring to two different versions of the lib (can't see `mapNullable` in AS).